### PR TITLE
Don't show demo when an error occurs

### DIFF
--- a/website/map/user.py
+++ b/website/map/user.py
@@ -61,6 +61,8 @@ class User(UserMixin):
         return ""
 
     def has_friend(self, friend_hash, ignore_dnd=False):
+        if friend_hash == "":
+            return False
         return self.get_friend(friend_hash, ignore_dnd) != ""
 
 class DisabledUser(User):


### PR DESCRIPTION
Additionally patches a situation where deleted machines were in other rooms.

We should improve the dev API so that it informs the user if a machine
is already in another room.